### PR TITLE
ci: ignore Go 1.27 RC versions in dependabot docker config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
       docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          - ">= 1.27.rc.1, < 1.27"


### PR DESCRIPTION
Add an `ignore` rule to the Docker ecosystem entry in `.github/dependabot.yml` to block Go 1.27 RC pre-releases (e.g. `1.27rc2-alpine3.23`) while leaving the eventual stable `1.27.0` open for updates. No equivalent rule needed for `gomod` or `github-actions` since their pre-release detection already filters RCs.