### PR TITLE
Add complete DNS response output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ doh [flags] [query type] [domain name]
 ```bash
 $ doh a google.com
 name: google.com
-type: 1
+type: 1 (A)
 ttl: 291
 data: 142.250.200.78
 ```
@@ -73,7 +73,7 @@ data: 142.250.200.78
 ```bash
 $ doh a google.com --provider google
 name: google.com.
-type: 1
+type: 1 (A)
 ttl: 300
 data: 142.250.184.14
 ```
@@ -83,7 +83,7 @@ data: 142.250.184.14
 ```bash
 $ doh a google.com --whois
 name: google.com
-type: 1
+type: 1 (A)
 ttl: 291
 data: 142.250.200.78
 whois: Google LLC
@@ -94,10 +94,27 @@ whois: Google LLC
 ```bash
 $ doh --json a google.com
 {
+  "status": 0,
+  "status_name": "NOERROR",
+  "flags": {
+    "tc": false,
+    "rd": true,
+    "ra": true,
+    "ad": false,
+    "cd": false
+  },
+  "question": [
+    {
+      "name": "google.com.",
+      "type": 1,
+      "type_name": "A"
+    }
+  ],
   "records": [
     {
       "name": "google.com",
       "type": 1,
+      "type_name": "A",
       "ttl": 115,
       "data": "142.251.36.14"
     }
@@ -110,10 +127,27 @@ $ doh --json a google.com
 ```bash
 $ doh --json --whois a google.com
 {
+  "status": 0,
+  "status_name": "NOERROR",
+  "flags": {
+    "tc": false,
+    "rd": true,
+    "ra": true,
+    "ad": false,
+    "cd": false
+  },
+  "question": [
+    {
+      "name": "google.com.",
+      "type": 1,
+      "type_name": "A"
+    }
+  ],
   "records": [
     {
       "name": "google.com",
       "type": 1,
+      "type_name": "A",
       "ttl": 47,
       "data": "142.250.179.206",
       "whois": "Google LLC"
@@ -121,3 +155,7 @@ $ doh --json --whois a google.com
   ]
 }
 ```
+
+JSON output also includes the DNS response status, flags, question, authority,
+additional, and comment sections when provided by the resolver. The `records`
+field remains the answer section for backward compatibility.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,9 @@ var rootCmd = &cobra.Command{
 			if outputErr := query.OutputTextResponse(rcodeErr.Response); outputErr != nil {
 				return outputErr
 			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", rcodeErr.Error())
+			if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", rcodeErr.Error()); printErr != nil {
+				return printErr
+			}
 			return nil // Prevent Cobra from printing usage for valid API DNS errors
 		}
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,9 @@ var rootCmd = &cobra.Command{
 		}
 		var rcodeErr query.RcodeError
 		if errors.As(err, &rcodeErr) {
+			if outputErr := query.OutputTextResponse(rcodeErr.Response); outputErr != nil {
+				return outputErr
+			}
 			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", rcodeErr.Error())
 			return nil // Prevent Cobra from printing usage for valid API DNS errors
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mxssl/doh
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/fatih/color v1.19.0

--- a/query/query.go
+++ b/query/query.go
@@ -245,6 +245,10 @@ func Whois(domain string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return whoisOrganization(result)
+}
+
+func whoisOrganization(result string) (string, error) {
 	lines := strings.Split(result, "\n")
 	for _, line := range lines {
 		if strings.HasPrefix(line, "OrgName:") {

--- a/query/query.go
+++ b/query/query.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,27 +25,75 @@ type dohResponse struct {
 		Name string `json:"name"`
 		Type int    `json:"type"`
 	} `json:"Question"`
-	Answer []struct {
-		Name string `json:"name"`
-		Type int    `json:"type"`
-		TTL  int    `json:"TTL"`
-		Data string `json:"data"`
-	} `json:"Answer"`
+	Answer     []dohRecord     `json:"Answer"`
+	Authority  []dohRecord     `json:"Authority"`
+	Additional []dohRecord     `json:"Additional"`
+	Comment    responseComment `json:"Comment"`
+}
+
+type dohRecord struct {
+	Name string `json:"name"`
+	Type int    `json:"type"`
+	TTL  int    `json:"TTL"`
+	Data string `json:"data"`
+}
+
+type responseComment []string
+
+func (c *responseComment) UnmarshalJSON(data []byte) error {
+	var comments []string
+	if err := json.Unmarshal(data, &comments); err == nil {
+		*c = comments
+		return nil
+	}
+
+	var comment string
+	if err := json.Unmarshal(data, &comment); err != nil {
+		return fmt.Errorf("invalid DNS response comment: %w", err)
+	}
+	if comment != "" {
+		*c = []string{comment}
+	}
+	return nil
 }
 
 // JSONOutput represents the output structure for JSON format
 type JSONOutput struct {
-	Records []DNSRecord `json:"records,omitempty"`
-	Error   string      `json:"error,omitempty"`
+	Status     int           `json:"status"`
+	StatusName string        `json:"status_name"`
+	Flags      DNSFlags      `json:"flags"`
+	Question   []DNSQuestion `json:"question,omitempty"`
+	Records    []DNSRecord   `json:"records,omitempty"`
+	Authority  []DNSRecord   `json:"authority,omitempty"`
+	Additional []DNSRecord   `json:"additional,omitempty"`
+	Comments   []string      `json:"comments,omitempty"`
+	Error      string        `json:"error,omitempty"`
+}
+
+// DNSQuestion represents the question section of a DNS response.
+type DNSQuestion struct {
+	Name     string `json:"name"`
+	Type     int    `json:"type"`
+	TypeName string `json:"type_name"`
+}
+
+// DNSFlags represents the response flags exposed by the DoH JSON APIs.
+type DNSFlags struct {
+	Truncated          bool `json:"tc"`
+	RecursionDesired   bool `json:"rd"`
+	RecursionAvailable bool `json:"ra"`
+	AuthenticData      bool `json:"ad"`
+	CheckingDisabled   bool `json:"cd"`
 }
 
 // DNSRecord represents a single DNS record in JSON output
 type DNSRecord struct {
-	Name  string `json:"name"`
-	Type  int    `json:"type"`
-	TTL   int    `json:"ttl"`
-	Data  string `json:"data"`
-	Whois string `json:"whois,omitempty"`
+	Name     string `json:"name"`
+	Type     int    `json:"type"`
+	TypeName string `json:"type_name"`
+	TTL      int    `json:"ttl"`
+	Data     string `json:"data"`
+	Whois    string `json:"whois,omitempty"`
 }
 
 // Provider URLs for DNS-over-HTTPS
@@ -180,7 +229,8 @@ func formatRcodeError(code int) string {
 
 // RcodeError indicates a valid DoH API DNS error response.
 type RcodeError struct {
-	Code int
+	Code     int
+	Response JSONOutput
 }
 
 func (e RcodeError) Error() string {
@@ -209,24 +259,94 @@ func Whois(domain string) (string, error) {
 
 // OutputJSONError prints an error in JSON format (exported for cmd package)
 func OutputJSONError(err error) {
-	output := JSONOutput{
-		Error: err.Error(),
+	var rcodeErr RcodeError
+	if !errors.As(err, &rcodeErr) {
+		jsonBytes, _ := json.MarshalIndent(struct {
+			Error string `json:"error"`
+		}{Error: err.Error()}, "", "  ")
+		fmt.Println(string(jsonBytes))
+		return
 	}
+	output := rcodeErr.Response
+	if output.StatusName == "" {
+		output.Status = rcodeErr.Code
+		output.StatusName = rcodeName(rcodeErr.Code)
+	}
+	output.Error = err.Error()
 	jsonBytes, _ := json.MarshalIndent(output, "", "  ")
 	fmt.Println(string(jsonBytes))
 }
 
 // outputJSON prints DNS records in JSON format
-func outputJSON(records []DNSRecord) error {
-	output := JSONOutput{
-		Records: records,
-	}
+func outputJSON(output JSONOutput) error {
 	jsonBytes, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		return fmt.Errorf("json marshal error: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
+}
+
+func makeDNSRecord(r dohRecord, enableWhois bool) DNSRecord {
+	record := DNSRecord{
+		Name:     r.Name,
+		Type:     r.Type,
+		TypeName: dnsTypeName(r.Type),
+		TTL:      r.TTL,
+		Data:     r.Data,
+	}
+	if enableWhois && ipRecordTypes[r.Type] {
+		if whoisResult, err := Whois(r.Data); err == nil && whoisResult != "" {
+			record.Whois = whoisResult
+		}
+	}
+	return record
+}
+
+func makeDNSRecords(records []dohRecord, enableWhois bool) []DNSRecord {
+	if len(records) == 0 {
+		return nil
+	}
+	result := make([]DNSRecord, 0, len(records))
+	for _, record := range records {
+		result = append(result, makeDNSRecord(record, enableWhois))
+	}
+	return result
+}
+
+func makeJSONOutput(res dohResponse, enableWhois bool) JSONOutput {
+	questions := make([]DNSQuestion, 0, len(res.Question))
+	for _, question := range res.Question {
+		questions = append(questions, DNSQuestion{
+			Name:     question.Name,
+			Type:     question.Type,
+			TypeName: dnsTypeName(question.Type),
+		})
+	}
+
+	return JSONOutput{
+		Status:     res.Status,
+		StatusName: rcodeName(res.Status),
+		Flags: DNSFlags{
+			Truncated:          res.Tc,
+			RecursionDesired:   res.Rd,
+			RecursionAvailable: res.Ra,
+			AuthenticData:      res.Ad,
+			CheckingDisabled:   res.Cd,
+		},
+		Question:   questions,
+		Records:    makeDNSRecords(res.Answer, enableWhois),
+		Authority:  makeDNSRecords(res.Authority, false),
+		Additional: makeDNSRecords(res.Additional, false),
+		Comments:   []string(res.Comment),
+	}
+}
+
+func rcodeName(code int) string {
+	if entries := rcodeByCode[code]; len(entries) != 0 {
+		return strings.ToUpper(entries[0].name)
+	}
+	return "UNKNOWN"
 }
 
 func Do(queryType string, domain string, enableWhois bool, enableJSON bool, provider string) error {
@@ -270,58 +390,56 @@ func Do(queryType string, domain string, enableWhois bool, enableJSON bool, prov
 		return fmt.Errorf("unmarshal error: %w", err)
 	}
 
+	output := makeJSONOutput(res, enableWhois)
 	if res.Status != 0 {
-		return RcodeError{Code: res.Status}
+		return RcodeError{Code: res.Status, Response: output}
 	}
 
-	if res.Answer == nil {
-		if enableJSON {
-			return outputJSON([]DNSRecord{})
-		}
-		fmt.Println("There is no such DNS record")
-		return nil
-	}
-
-	// JSON output mode
 	if enableJSON {
-		var records []DNSRecord
-		for _, r := range res.Answer {
-			record := DNSRecord{
-				Name: r.Name,
-				Type: r.Type,
-				TTL:  r.TTL,
-				Data: r.Data,
-			}
-
-			// Only perform WHOIS lookup for IP address records if enabled
-			if enableWhois && ipRecordTypes[r.Type] {
-				whoisResult, err := Whois(r.Data)
-				if err == nil && whoisResult != "" {
-					record.Whois = whoisResult
-				}
-			}
-
-			records = append(records, record)
-		}
-		return outputJSON(records)
+		return outputJSON(output)
 	}
+	return outputText(output)
+}
 
-	// Colored text output mode (existing code)
+// OutputTextResponse prints a parsed DNS response in human-readable form.
+func OutputTextResponse(output JSONOutput) error {
+	return outputText(output)
+}
+
+func outputText(output JSONOutput) error {
 	green := color.New(color.FgGreen).SprintFunc()
 	blue := color.New(color.FgBlue).SprintFunc()
-	for _, r := range res.Answer {
-		fmt.Printf("%s: %v\n", blue("name"), green(r.Name))
-		fmt.Printf("%s: %v\n", blue("type"), green(r.Type))
-		fmt.Printf("%s: %v\n", blue("ttl"), green(r.TTL))
-		fmt.Printf("%s: %v\n", blue("data"), green(r.Data))
 
-		// Only perform WHOIS lookup for IP address records (A and AAAA) if enabled
-		if enableWhois && ipRecordTypes[r.Type] {
-			whois, err := Whois(r.Data)
-			if err == nil && whois != "" {
-				fmt.Printf("%s: %v\n", blue("whois"), green(whois))
-			}
-		}
+	hasOtherSections := len(output.Authority) > 0 || len(output.Additional) > 0 || len(output.Comments) > 0
+	if len(output.Records) == 0 {
+		fmt.Println("No answer records")
+	} else if hasOtherSections {
+		fmt.Println(blue("answer:"))
+	}
+	printRecords(output.Records, blue, green)
+
+	if len(output.Authority) > 0 {
+		fmt.Println(blue("authority:"))
+		printRecords(output.Authority, blue, green)
+	}
+	if len(output.Additional) > 0 {
+		fmt.Println(blue("additional:"))
+		printRecords(output.Additional, blue, green)
+	}
+	for _, comment := range output.Comments {
+		fmt.Printf("%s: %v\n", blue("comment"), green(comment))
 	}
 	return nil
+}
+
+func printRecords(records []DNSRecord, blue, green func(a ...interface{}) string) {
+	for _, r := range records {
+		fmt.Printf("%s: %v\n", blue("name"), green(r.Name))
+		fmt.Printf("%s: %v\n", blue("type"), green(fmt.Sprintf("%d (%s)", r.Type, r.TypeName)))
+		fmt.Printf("%s: %v\n", blue("ttl"), green(r.TTL))
+		fmt.Printf("%s: %v\n", blue("data"), green(r.Data))
+		if r.Whois != "" {
+			fmt.Printf("%s: %v\n", blue("whois"), green(r.Whois))
+		}
+	}
 }

--- a/query/query.go
+++ b/query/query.go
@@ -437,7 +437,10 @@ func outputText(output JSONOutput) error {
 }
 
 func printRecords(records []DNSRecord, blue, green func(a ...interface{}) string) {
-	for _, r := range records {
+	for i, r := range records {
+		if i > 0 {
+			fmt.Println()
+		}
 		fmt.Printf("%s: %v\n", blue("name"), green(r.Name))
 		fmt.Printf("%s: %v\n", blue("type"), green(fmt.Sprintf("%d (%s)", r.Type, r.TypeName)))
 		fmt.Printf("%s: %v\n", blue("ttl"), green(r.TTL))

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -412,6 +412,28 @@ func TestDoSuccessTextOutput(t *testing.T) {
 	}
 }
 
+func TestTextOutputSeparatesMultipleAnswerRecords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dns-json")
+		_, _ = w.Write([]byte(`{"Status":0,"Answer":[
+			{"name":"example.com.","type":1,"TTL":120,"data":"192.0.2.1"},
+			{"name":"example.com.","type":1,"TTL":120,"data":"192.0.2.2"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	provider := addTestProvider(t, srv.URL)
+	out := captureStdout(t, func() {
+		if err := Do("A", "example.com", false, false, provider); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "data: 192.0.2.1\n\nname: example.com.") {
+		t.Fatalf("expected a blank line between answer records: %q", out)
+	}
+}
+
 func TestDoOutputsAllResponseSections(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/dns-json")

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -131,6 +131,9 @@ func TestOutputJSONErrorForRcodeError(t *testing.T) {
 	if strings.Contains(out, `"error_code"`) {
 		t.Fatalf("json output must not contain error_code field: %s", out)
 	}
+	if !strings.Contains(out, `"status": 3`) || !strings.Contains(out, `"status_name": "NXDOMAIN"`) {
+		t.Fatalf("json output missing DNS response status: %s", out)
+	}
 }
 
 func addTestProvider(t *testing.T, url string) string {
@@ -233,7 +236,7 @@ func TestDoNoAnswerTextOutput(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(out, "There is no such DNS record") {
+	if !strings.Contains(out, "No answer records") {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
@@ -288,6 +291,9 @@ func TestDoSuccessJSONOutput(t *testing.T) {
 	if rec.Name != "example.com." || rec.Type != 1 || rec.TTL != 120 || rec.Data != "93.184.216.34" {
 		t.Fatalf("unexpected record: %+v", rec)
 	}
+	if rec.TypeName != "A" {
+		t.Fatalf("unexpected record type name; got %q, want A", rec.TypeName)
+	}
 }
 
 func TestDoSuccessTextOutput(t *testing.T) {
@@ -308,7 +314,7 @@ func TestDoSuccessTextOutput(t *testing.T) {
 	if !strings.Contains(out, "name: example.com.") {
 		t.Fatalf("missing record name in output: %s", out)
 	}
-	if !strings.Contains(out, "type: 1") {
+	if !strings.Contains(out, "type: 1 (A)") {
 		t.Fatalf("missing record type in output: %s", out)
 	}
 	if !strings.Contains(out, "ttl: 120") {
@@ -316,5 +322,76 @@ func TestDoSuccessTextOutput(t *testing.T) {
 	}
 	if !strings.Contains(out, "data: 93.184.216.34") {
 		t.Fatalf("missing record data in output: %s", out)
+	}
+}
+
+func TestDoOutputsAllResponseSections(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dns-json")
+		_, _ = w.Write([]byte(`{
+			"Status": 0,
+			"TC": false,
+			"RD": true,
+			"RA": true,
+			"AD": true,
+			"CD": false,
+			"Question": [{"name":"example.com.","type":15}],
+			"Answer": [{"name":"example.com.","type":15,"TTL":300,"data":"10 mail.example.com."}],
+			"Authority": [{"name":"example.com.","type":6,"TTL":600,"data":"ns.example.com. hostmaster.example.com. 1 2 3 4 5"}],
+			"Additional": [{"name":"mail.example.com.","type":1,"TTL":300,"data":"192.0.2.10"}],
+			"Comment": ["cached response"]
+		}`))
+	}))
+	defer srv.Close()
+
+	provider := addTestProvider(t, srv.URL)
+	out := captureStdout(t, func() {
+		if err := Do("mx", "example.com", false, true, provider); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	var got JSONOutput
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected valid json, got %q: %v", out, err)
+	}
+	if got.Status != 0 || got.StatusName != "NOERROR" {
+		t.Fatalf("unexpected response status: %d (%s)", got.Status, got.StatusName)
+	}
+	if !got.Flags.RecursionDesired || !got.Flags.RecursionAvailable || !got.Flags.AuthenticData {
+		t.Fatalf("unexpected response flags: %+v", got.Flags)
+	}
+	if len(got.Question) != 1 || got.Question[0].TypeName != "MX" {
+		t.Fatalf("unexpected question section: %+v", got.Question)
+	}
+	if len(got.Records) != 1 || got.Records[0].TypeName != "MX" {
+		t.Fatalf("unexpected answer section: %+v", got.Records)
+	}
+	if len(got.Authority) != 1 || got.Authority[0].TypeName != "SOA" {
+		t.Fatalf("unexpected authority section: %+v", got.Authority)
+	}
+	if len(got.Additional) != 1 || got.Additional[0].TypeName != "A" {
+		t.Fatalf("unexpected additional section: %+v", got.Additional)
+	}
+	if len(got.Comments) != 1 || got.Comments[0] != "cached response" {
+		t.Fatalf("unexpected comments: %+v", got.Comments)
+	}
+}
+
+func TestResponseCommentAcceptsStringAndArray(t *testing.T) {
+	for _, input := range []string{`"diagnostic"`, `["diagnostic"]`} {
+		var got responseComment
+		if err := json.Unmarshal([]byte(input), &got); err != nil {
+			t.Fatalf("failed to unmarshal %s: %v", input, err)
+		}
+		if len(got) != 1 || got[0] != "diagnostic" {
+			t.Fatalf("unexpected comment for %s: %+v", input, got)
+		}
+	}
+}
+
+func TestUnknownTypeNameUsesGenericNotation(t *testing.T) {
+	if got, want := dnsTypeName(65400), "TYPE65400"; got != want {
+		t.Fatalf("unexpected unknown type name; got %q, want %q", got, want)
 	}
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -13,6 +13,22 @@ import (
 	"testing"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (errorReadCloser) Close() error {
+	return nil
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
@@ -136,6 +152,20 @@ func TestOutputJSONErrorForRcodeError(t *testing.T) {
 	}
 }
 
+func TestOutputJSONErrorForTransportError(t *testing.T) {
+	out := captureStdout(t, func() {
+		OutputJSONError(errors.New("transport failed"))
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected valid json, got %q: %v", out, err)
+	}
+	if got["error"] != "transport failed" || len(got) != 1 {
+		t.Fatalf("unexpected error output: %v", got)
+	}
+}
+
 func addTestProvider(t *testing.T, url string) string {
 	t.Helper()
 
@@ -173,6 +203,63 @@ func TestDoReturnsRcodeError(t *testing.T) {
 	}
 	if rcodeErr.Code != 3 {
 		t.Fatalf("unexpected rcode value; got %d, want %d", rcodeErr.Code, 3)
+	}
+	if rcodeErr.Response.Status != 3 || rcodeErr.Response.StatusName != "NXDOMAIN" {
+		t.Fatalf("unexpected response on rcode error: %+v", rcodeErr.Response)
+	}
+}
+
+func TestDoBuildsProviderRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Query().Get("name"), "example.com"; got != want {
+			t.Errorf("unexpected query name; got %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("type"), "HTTPS"; got != want {
+			t.Errorf("unexpected query type; got %q, want %q", got, want)
+		}
+		if got, want := r.Header.Get("Accept"), "application/dns-json"; got != want {
+			t.Errorf("unexpected Accept header; got %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/dns-json")
+		_, _ = w.Write([]byte(`{"Status":0}`))
+	}))
+	defer srv.Close()
+
+	provider := addTestProvider(t, srv.URL)
+	_ = captureStdout(t, func() {
+		if err := Do("HTTPS", "example.com", false, false, provider); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+}
+
+func TestDoRequestError(t *testing.T) {
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection failed")
+	})}
+	t.Cleanup(func() { http.DefaultClient = oldClient })
+
+	err := Do("A", "example.com", false, false, DefaultProvider)
+	if err == nil || !strings.Contains(err.Error(), "request do error") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoReadBodyError(t *testing.T) {
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errorReadCloser{},
+			Header:     make(http.Header),
+		}, nil
+	})}
+	t.Cleanup(func() { http.DefaultClient = oldClient })
+
+	err := Do("A", "example.com", false, false, DefaultProvider)
+	if err == nil || !strings.Contains(err.Error(), "read body error") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -387,6 +474,76 @@ func TestResponseCommentAcceptsStringAndArray(t *testing.T) {
 		if len(got) != 1 || got[0] != "diagnostic" {
 			t.Fatalf("unexpected comment for %s: %+v", input, got)
 		}
+	}
+}
+
+func TestResponseCommentHandlesEmptyAndInvalidValues(t *testing.T) {
+	var empty responseComment
+	if err := json.Unmarshal([]byte(`""`), &empty); err != nil {
+		t.Fatalf("failed to unmarshal empty comment: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected no comments, got %+v", empty)
+	}
+
+	var invalid responseComment
+	if err := json.Unmarshal([]byte(`{"message":"bad"}`), &invalid); err == nil {
+		t.Fatal("expected invalid comment shape to fail")
+	}
+}
+
+func TestOutputTextResponseIncludesAllSections(t *testing.T) {
+	output := JSONOutput{
+		Records:    []DNSRecord{{Name: "example.com.", Type: 15, TypeName: "MX", TTL: 300, Data: "10 mail.example.com."}},
+		Authority:  []DNSRecord{{Name: "example.com.", Type: 6, TypeName: "SOA", TTL: 600, Data: "ns.example.com. hostmaster.example.com. 1 2 3 4 5"}},
+		Additional: []DNSRecord{{Name: "mail.example.com.", Type: 1, TypeName: "A", TTL: 300, Data: "192.0.2.10", Whois: "Example Org"}},
+		Comments:   []string{"cached response"},
+	}
+
+	out := captureStdout(t, func() {
+		if err := OutputTextResponse(output); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+	for _, expected := range []string{
+		"answer:", "type: 15 (MX)", "authority:", "type: 6 (SOA)",
+		"additional:", "type: 1 (A)", "whois: Example Org", "comment: cached response",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("output missing %q: %s", expected, out)
+		}
+	}
+}
+
+func TestWhoisOrganization(t *testing.T) {
+	tests := []struct {
+		name   string
+		result string
+		want   string
+	}{
+		{name: "ARIN", result: "NetRange: 192.0.2.0 - 192.0.2.255\nOrgName: Example Org\n", want: "Example Org"},
+		{name: "RIPE", result: "inetnum: 192.0.2.0/24\norg-name: Example Europe\n", want: "Example Europe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := whoisOrganization(tt.result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected organization; got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	if _, err := whoisOrganization("no organization here"); err == nil {
+		t.Fatal("expected missing organization error")
+	}
+}
+
+func TestRcodeNameUnknown(t *testing.T) {
+	if got, want := rcodeName(65400), "UNKNOWN"; got != want {
+		t.Fatalf("unexpected rcode name; got %q, want %q", got, want)
 	}
 }
 

--- a/query/types.go
+++ b/query/types.go
@@ -1,0 +1,31 @@
+package query
+
+import "strconv"
+
+// Names from the IANA DNS Resource Record (RR) TYPE registry.
+var dnsTypeNames = map[int]string{
+	0: "Reserved", 1: "A", 2: "NS", 3: "MD", 4: "MF", 5: "CNAME",
+	6: "SOA", 7: "MB", 8: "MG", 9: "MR", 10: "NULL", 11: "WKS",
+	12: "PTR", 13: "HINFO", 14: "MINFO", 15: "MX", 16: "TXT", 17: "RP",
+	18: "AFSDB", 19: "X25", 20: "ISDN", 21: "RT", 22: "NSAP", 23: "NSAP-PTR",
+	24: "SIG", 25: "KEY", 26: "PX", 27: "GPOS", 28: "AAAA", 29: "LOC",
+	30: "NXT", 31: "EID", 32: "NIMLOC", 33: "SRV", 34: "ATMA", 35: "NAPTR",
+	36: "KX", 37: "CERT", 38: "A6", 39: "DNAME", 40: "SINK", 41: "OPT",
+	42: "APL", 43: "DS", 44: "SSHFP", 45: "IPSECKEY", 46: "RRSIG", 47: "NSEC",
+	48: "DNSKEY", 49: "DHCID", 50: "NSEC3", 51: "NSEC3PARAM", 52: "TLSA",
+	53: "SMIMEA", 55: "HIP", 56: "NINFO", 57: "RKEY", 58: "TALINK", 59: "CDS",
+	60: "CDNSKEY", 61: "OPENPGPKEY", 62: "CSYNC", 63: "ZONEMD", 64: "SVCB",
+	65: "HTTPS", 66: "DSYNC", 67: "HHIT", 68: "BRID", 99: "SPF", 100: "UINFO",
+	101: "UID", 102: "GID", 103: "UNSPEC", 104: "NID", 105: "L32", 106: "L64",
+	107: "LP", 108: "EUI48", 109: "EUI64", 128: "NXNAME", 249: "TKEY",
+	250: "TSIG", 251: "IXFR", 252: "AXFR", 253: "MAILB", 254: "MAILA", 255: "ANY",
+	256: "URI", 257: "CAA", 258: "AVC", 259: "DOA", 260: "AMTRELAY",
+	261: "RESINFO", 262: "WALLET", 263: "CLA", 264: "IPN", 32768: "TA", 32769: "DLV",
+}
+
+func dnsTypeName(recordType int) string {
+	if name, ok := dnsTypeNames[recordType]; ok {
+		return name
+	}
+	return "TYPE" + strconv.Itoa(recordType)
+}


### PR DESCRIPTION
## Summary

- expose DNS status, flags, question, authority, additional, and comment sections
- retain `records` as the answer section for backward compatibility
- display record types as `N (NAME)` in text output and add `type_name` to JSON
- normalize Cloudflare array comments and Google string comments
- preserve response context for DNS RCODE errors
- update the project Go version to 1.26.5

## Why

The client previously discarded all response data outside the answer section, which hid delegation details, negative-response SOA records, additional records, and resolver diagnostics.

## Impact

Existing JSON consumers can continue reading the numeric `type` and `records` fields. New response metadata is additive, and text output now includes human-readable record type names.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- live Cloudflare HTTPS and NXDOMAIN queries